### PR TITLE
Default language set to English, extend the others, changed 'in' to 'enum'

### DIFF
--- a/lib/praetorian.js
+++ b/lib/praetorian.js
@@ -156,8 +156,8 @@
 					}
 					return this;
 				},
-				in: function( permittedValuesArray ) {
-					console.log( 'in check', permittedValuesArray );
+				enum: function( permittedValuesArray ) {
+					console.log( 'enum check', permittedValuesArray );
 					if( _.indexOf( permittedValuesArray, check.data ) === -1 ) {
 						check.error = options.messages.VALUE_NOT_IN_ARRAY;
 					}

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ praetorian = new Praetorian(
 		},
 		"myInValidator": {
 			"rules": {
-				"in": [
+				"enum": [
 					"Y", "N", "T", "A"
 				]
 			},


### PR DESCRIPTION
Default language set to English, extend the others when in use. This will prevent to forget error messages.

Changed 'in' to 'enum'
