### PR TITLE
#12 Allow basic array value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## **0.2.0**
+[**#12**](https://github.com/Shortbreaks/praetorian/issues/12) Allow basic arrays for type `array`

--- a/lib/praetorian.js
+++ b/lib/praetorian.js
@@ -338,15 +338,20 @@
 						/* Array */
 						// check its ACTUALLY an array
 						if( _.isArray( json[levelKey] ) ) {
-							// loop each element in the array and parse those as individual objects against their schema
-							_.each( json[levelKey], function( arrayElement, loopCount ) {
-								if( !_.isUndefined( arrayElement ) ) {
-									parseJson( arrayElement, schema[levelKey].items, levelKey + '[' + loopCount + '].' );
-								} else {
-									// in this instance, an element in the array was not passed at all , no harm done
-									// i.e. name[0].initial was not passed but name[1].initial was
-								}
-							} );
+							// Does the schema say there should be items?
+							if( schema[levelKey].items ) {
+								// loop each element in the array and parse those as individual objects against their schema
+								_.each( json[levelKey], function( arrayElement, loopCount ) {
+									if( !_.isUndefined( arrayElement ) ) {
+										parseJson( arrayElement, schema[levelKey].items, levelKey + '[' + loopCount + '].' );
+									} else {
+										// in this instance, an element in the array was not passed at all , no harm done
+										// i.e. name[0].initial was not passed but name[1].initial was
+									}
+								} );
+							} else {
+								// Schema says no "items" and as the value is an array, happy with that
+							}
 						} else {
 							// ERROR: this value should be an ARRAY but it's not (object of some other description?)
 							addError( elementPrefix + levelKey, self.options.messages.VALUE_TYPE_MUST_BE_ARRAY );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetorian",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "A structured JSON parser and validator",
   "main": "index.js",
   "license": "MIT",

--- a/test/json/gracchus.json
+++ b/test/json/gracchus.json
@@ -19,8 +19,8 @@
 				"circle": true,
 				"square": true
 			}
-		]
-			
+		],
+		"city": [ 0 ]			
 	},
 	"schema": {
 		"cars": {
@@ -87,6 +87,10 @@
 					"type" : "boolean"
 				}
 			}
+		},
+		"city": {
+			"required": false,
+			"type" : "array"
 		}
 	},
 	"expected": {
@@ -109,6 +113,7 @@
 				"circle": true,
 				"square": true
 			}
-		]
+		],
+		"city": [ 0 ]
 	}
 }


### PR DESCRIPTION
Will allow a primitive array value through when validating a type of `array`